### PR TITLE
Add StorageType.AppDomainData-2

### DIFF
--- a/PersistentObjectCache.net45/IsoStorage.cs
+++ b/PersistentObjectCache.net45/IsoStorage.cs
@@ -33,9 +33,25 @@ namespace PersistentObjectCachenetcore451
     /// <remarks>   Sander.struijk, 25.04.2014. </remarks>
     public enum StorageType
     {
+        /// <summary>
+        /// Location of Environment.SpecialFolder.LocalApplicationData
+        /// </summary>
         Local,
+
+        /// <summary>
+        /// The OS System folder temp directory
+        /// </summary>
         Temporary,
-        Roaming
+
+        /// <summary>
+        /// Roaming folder located at Environment.SpecialFolder.ApplicationData
+        /// </summary>
+        Roaming,
+
+        /// <summary>
+        /// Location provided by AppDomain.CurrentDomain.GetData("DataDirectory")
+        /// </summary>
+        AppDomainData
     }
 
     /// <summary>   An ISO storage. </summary>
@@ -91,6 +107,9 @@ namespace PersistentObjectCachenetcore451
                         break;
                     case StorageType.Roaming:
                         _baseStoragePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                        break;
+                    case StorageType.AppDomainData:
+                        _baseStoragePath = AppDomain.CurrentDomain.GetData("DataDirectory").ToString();
                         break;
                     default:
                         throw new Exception(String.Format("Unknown StorageType: {0}", _storageType));


### PR DESCRIPTION
Allow ASP.NET apps to easily write to the ~\App_Data\ location. The
default "Local" location is wiped upon IIS recycling unless
nonstandard-configuration of LoadUserProfile is added. Also add some
documentation to enum members
